### PR TITLE
fix: xcode 12 compatibility

### DIFF
--- a/ios/RNAirplay.podspec
+++ b/ios/RNAirplay.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
   #s.dependency "others"
 
 end


### PR DESCRIPTION
Xcode 12 fails to build if a module depends on React instead of React-Core. 
More info: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116